### PR TITLE
(MAINT) Add group formatting

### DIFF
--- a/cmd/play/play.go
+++ b/cmd/play/play.go
@@ -3,8 +3,10 @@ package play
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/FlagrantGarden/flfa/pkg/flfa"
+	"github.com/FlagrantGarden/flfa/pkg/terminal_documentation"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -55,6 +57,26 @@ func (p *PlayCommand) execute(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Your group is: %+v", group)
+
+	switch viper.GetString("format") {
+	case "json":
+		{
+			fmt.Print(group.JSON())
+		}
+	default:
+		{
+			groupOutput := strings.Builder{}
+			groupOutput.WriteString("| Name | Base Profile | Melee | Missile | Move | FS | R | T | Traits |\n")
+			groupOutput.WriteString("| ---- | ------------ | ----- | ------- | ---- | -- | - | - | ------ |\n")
+			groupOutput.WriteString(group.MarkdownTableEntry())
+			td := terminal_documentation.TerminalDocumentation{}
+			output, err := td.Render(groupOutput.String())
+			if err != nil {
+				return err
+			}
+			fmt.Print(output)
+		}
+	}
+
 	return nil
 }

--- a/pkg/flfa/base_profiles.go
+++ b/pkg/flfa/base_profiles.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
@@ -132,4 +133,44 @@ func GetBaseProfileTraits(profile BaseProfile, traitList []Trait) []Trait {
 		}
 	}
 	return traits
+}
+
+func (m *Melee) String() string {
+	output := strings.Builder{}
+	if m.Activation == 0 {
+		output.WriteString("- / ")
+	} else {
+		output.WriteString(fmt.Sprintf("%d+ / ", m.Activation))
+	}
+	if m.ToHitAttacking == 0 {
+		output.WriteString("- / ")
+	} else if m.ToHitAttacking < 6 {
+		output.WriteString(fmt.Sprintf("%d+ / ", m.ToHitAttacking))
+	} else {
+		output.WriteString("6 / ")
+	}
+	if m.ToHitDefending < 6 {
+		output.WriteString(fmt.Sprintf("%d+", m.ToHitDefending))
+	} else {
+		output.WriteString("6")
+	}
+	return output.String()
+}
+
+func (m *Missile) String() string {
+	output := strings.Builder{}
+	if m.Activation == 0 {
+		output.WriteString("- / - / -")
+	} else {
+		output.WriteString(fmt.Sprintf("%d+ / %d+ / %d\"", m.Activation, m.ToHit, m.Range))
+	}
+	return output.String()
+}
+
+func (m *Move) String() string {
+	return fmt.Sprintf("%d+ / %d\"", m.Activation, m.Distance)
+}
+
+func (fs *FightingStrength) String() string {
+	return fmt.Sprintf("%d / %d", fs.Current, fs.Maximum)
 }


### PR DESCRIPTION
Prior to this PR, no formatting existed for groups, meaning that the only way to display them was to blurt the values of the struct via `%v` string interpolation.

This commit:

- Adds the `String()` function for the `Melee`, `Missile`, `Move`, and `FightingStrength` structs, making their non-data representation simpler where needed
- Adds the `MarkdownTableEntry()` and `JSON()` functions to the `Group` struct, enabling output of a group in either human or machine readable formats
- Updates the play command to return the JSON representation of the created group (if the user passes `json` to the `format` flag) or a markdown table representation of the created group (by default or if the user passes `human` to the `format` flag).

This improves the readability of groups in the terminal and for any future external consumers of the data model.