### PR TITLE
(MAINT) Add option to copy group in company builder

### DIFF
--- a/pkg/flfa/tui/company/commands.go
+++ b/pkg/flfa/tui/company/commands.go
@@ -126,10 +126,12 @@ func (model *Model) UpdateEditingChoice() (cmd tea.Cmd) {
 		cmd = model.SetAndStartSubstate(Redescribing)
 	case "Change Name":
 		cmd = model.SetAndStartSubstate(Renaming)
-	case "Add a new Group":
+	case "Create & add a new Group":
 		cmd = model.SetAndStartSubstate(AddingGroup)
 	case "Edit a Group":
 		cmd = model.SetAndStartSubstate(SelectingGroupToEdit)
+	case "Add a copy of a Group":
+		cmd = model.SetAndStartSubstate(CopyingGroup)
 	case "Remove a Group":
 		cmd = model.SetAndStartSubstate(RemovingGroup)
 	case "Update Captaincy":
@@ -163,6 +165,9 @@ func (model *Model) UpdateGroupSelection() (cmd tea.Cmd) {
 		cmd = model.Group.Init()
 	case SelectingGroupToPromote:
 		model.Groups[choice.Index].PromoteToCaptain(nil, data.FilterTraitsBySource("core", model.Api.Cache.Traits)...)
+		cmd = model.SetAndStartSubstate(SelectingOption)
+	case CopyingGroup:
+		model.Groups = append(model.Groups, selectedGroup)
 		cmd = model.SetAndStartSubstate(SelectingOption)
 	case RemovingGroup:
 		model.Groups = utils.RemoveIndex(model.Groups, choice.Index)

--- a/pkg/flfa/tui/company/prompts/prompts.go
+++ b/pkg/flfa/tui/company/prompts/prompts.go
@@ -62,7 +62,8 @@ func SelectOption(canRemoveAGroup bool, hasCaptain bool) *selection.Selection {
 		"Save & Continue",
 		"Change Name",
 		"Change Description",
-		"Add a new Group",
+		"Create & add a new Group",
+		"Add a copy of a Group",
 		"Edit a Group",
 	}
 
@@ -91,6 +92,7 @@ type SelectGroupFor int
 
 const (
 	Editing SelectGroupFor = iota
+	Copying
 	Promoting
 	Removing
 )
@@ -121,6 +123,8 @@ func SelectGroup(action SelectGroupFor, groups []data.Group) (prompt *selection.
 
 	var message strings.Builder
 	switch action {
+	case Copying:
+		message.WriteString("Which Group would you like to make a copy of?\n")
 	case Editing:
 		message.WriteString("Which Group would you like to edit?\n")
 	case Promoting:
@@ -239,10 +243,6 @@ func SelectRerollCaptainTrait(group data.Group, availableTraits []data.Trait) *s
 			messageStyle.Render(fmt.Sprintf("» %s", info.Message)),
 			effectStyle.Render(info.Trait.Effect),
 		)
-		// return lipgloss.NewStyle().
-		// 	Bold(true).
-		// 	Foreground(lipgloss.Color("32")).
-		// 	Render(fmt.Sprintf("» %s", choice.Value.(CaptainTraitChoice).Message))
 	}
 
 	unselectedChoiceStyle := func(choice *selection.Choice) string {
@@ -252,7 +252,6 @@ func SelectRerollCaptainTrait(group data.Group, availableTraits []data.Trait) *s
 			lipgloss.NewStyle().Width(maxWidth).PaddingRight(2).Render(fmt.Sprintf("  %s", info.Message)),
 			lipgloss.NewStyle().Width(120-2-maxWidth).Faint(true).Render(info.Trait.Effect),
 		)
-		// return fmt.Sprintf("  %s", choice.Value.(CaptainTraitChoice).Message)
 	}
 
 	return selector.NewStructSelector(

--- a/pkg/flfa/tui/company/substate_editing.go
+++ b/pkg/flfa/tui/company/substate_editing.go
@@ -19,6 +19,7 @@ const (
 	SelectingGroupToEdit
 	SelectingGroupToPromote
 	EditingGroup
+	CopyingGroup
 	RemovingGroup
 	SelectingCaptainOption
 	RerollingCaptainTrait
@@ -52,6 +53,9 @@ func (state SubstateEditing) Start(model *Model) (cmd tea.Cmd) {
 		cmd = model.Selection.Init()
 	case EditingGroup:
 		// ??
+	case CopyingGroup:
+		model.Selection = prompts.SelectGroupModel(prompts.Copying, model.Groups)
+		cmd = model.Selection.Init()
 	case RemovingGroup:
 		model.Selection = prompts.SelectGroupModel(prompts.Removing, model.Groups)
 		cmd = model.Selection.Init()
@@ -114,7 +118,7 @@ func (state SubstateEditing) UpdateOnEnter(model *Model) (cmd tea.Cmd) {
 		return model.UpdateName(SelectingOption)
 	case Redescribing:
 		return model.UpdateDescription(SelectingOption)
-	case SelectingGroupToEdit, SelectingGroupToPromote, RemovingGroup, SelectingCaptainReplacement:
+	case SelectingGroupToEdit, SelectingGroupToPromote, RemovingGroup, SelectingCaptainReplacement, CopyingGroup:
 		return model.UpdateGroupSelection()
 	case SelectingCaptainOption:
 		return model.UpdateCaptainSelection()
@@ -156,7 +160,7 @@ func (state SubstateEditing) UpdateOnFallThrough(model *Model, msg tea.Msg) (cmd
 	switch model.Substate.Editing {
 	case ConfirmingCaptainDemotion, ConfirmingCaptainReplacement:
 		_, cmd = model.Confirmation.Update(msg)
-	case SelectingOption, SelectingCaptainOption, RemovingGroup,
+	case SelectingOption, SelectingCaptainOption, RemovingGroup, CopyingGroup,
 		SelectingGroupToEdit, SelectingGroupToPromote, SelectingCaptainTrait,
 		RerollingCaptainTrait, SelectingCaptainReplacement:
 		_, cmd = model.Selection.Update(msg)


### PR DESCRIPTION
This commit adds the option to copy an existing group to the company instead
of requiring the user too recreate the group every time they want to add it.